### PR TITLE
Rename hlgraphql to rlgraphql in configuration and documentation

### DIFF
--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -36,14 +36,14 @@ jobs:
             fi
           done
 
-      - name: Creating database hlgraphql
-        run: psql "postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable" -c "CREATE DATABASE hlgraphql WITH TEMPLATE = template0 ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';"
+      - name: Creating database rlgraphql
+        run: psql "postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable" -c "CREATE DATABASE rlgraphql WITH TEMPLATE = template0 ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';"
 
       - name: Using Postgres DB
         run: |
           export POSTGRES_HOST=localhost
           export POSTGRES_PORT=5432
-          export POSTGRES_DB=hlgraphql
+          export POSTGRES_DB=rlgraphql
           export POSTGRES_USER=postgres
           export POSTGRES_PASSWORD=password
           export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,7 +42,6 @@
         "Graphile",
         "gsrpc",
         "hexutil",
-        "hlgraphql",
         "idempotency",
         "initdb",
         "inputbox",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cartesi's HL GraphQL
+# Cartesi's GraphQL
 
 ![CI](https://github.com/Calindra/cartesi-rollups-graphql/actions/workflows/ci.yaml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Calindra/cartesi-rollups-graphql)](https://goreportcard.com/report/github.com/Calindra/cartesi-rollups-graphql)
@@ -9,7 +9,7 @@
 
 ## Description
 
-Exposes the High Level GraphQL reader API in the endpoint `http://127.0.0.1:8080/graphql`.
+Exposes the GraphQL reader API in the endpoint `http://127.0.0.1:8080/graphql`.
 You may access this address to use the GraphQL interactive playground in your web browser.
 You can also make POST requests directly to the GraphQL API.
 For instance, the command below gets the number of inputs.
@@ -55,8 +55,6 @@ export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollups
 
 ## Contributors
 
-<a href="https://github.com/Calindra/cartesi-rollups-graphql/graphs/contributors">
-  <img src="https://contributors-img.firebaseapp.com/image?repo=calindra/cartesi-rollups-graphql" />
-</a>
+[![Contributors](https://contributors-img.firebaseapp.com/image?repo=Calindra/cartesi-rollups-graphql)](https://github.com/Calindra/cartesi-rollups-graphql/graphs/contributors)
 
 Made with [contributors-img](https://contributors-img.firebaseapp.com).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ make up-db-raw
 New configuration
 
 ```sh
-export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@localhost:5432/hlgraphql?sslmode=disable"
+export POSTGRES_GRAPHQL_DB_URL="postgres://postgres:password@localhost:5432/rlgraphql?sslmode=disable"
 export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
 ./cartesi-rollups-graphql
 ```
@@ -46,7 +46,7 @@ When running cartesi-rollups-graphql, set flag db-implementation with the value 
 ```sh
 export POSTGRES_HOST=localhost
 export POSTGRES_PORT=5432
-export POSTGRES_DB=hlgraphql
+export POSTGRES_DB=rlgraphql
 export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=password
 export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 // Copyright (c) Gabriel de Quadros Ligneul
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-// This package contains the main function that executes the hlgraphql command.
+// This package contains the main function that executes the cartesi-rollups-graphql command.
 package main
 
 import (
@@ -40,8 +40,8 @@ Press Ctrl+C to stop the node
 var tempFromBlockL1 uint64
 
 var cmd = &cobra.Command{
-	Use:     "hlgraphql [flags] [-- application [args]...]",
-	Short:   "hlgraphql is a development node for Cartesi Rollups",
+	Use:     "cartesi-rollups-graphql [flags] [-- application [args]...]",
+	Short:   "cartesi-rollups-graphql is a development node for Cartesi Rollups",
 	Run:     run,
 	Version: versioninfo.Short(),
 }
@@ -102,24 +102,24 @@ func init() {
 	cmd.Flags().BoolVarP(&debug, "enable-debug", "d", false, "If set, enable debug output")
 	cmd.Flags().BoolVar(&color, "enable-color", true, "If set, enables logs color")
 	cmd.Flags().BoolVar(&opts.EnableEcho, "enable-echo", opts.EnableEcho,
-		"If set, hlgraphql starts a built-in echo application")
+		"If set, cartesi-rollups-graphql starts a built-in echo application")
 
-	cmd.Flags().DurationVar(&opts.TimeoutWorker, "timeout-worker", opts.TimeoutWorker, "Timeout for workers. Example: hlgraphql --timeout-worker 30s")
-	cmd.Flags().DurationVar(&opts.TimeoutInspect, "sm-deadline-inspect-state", opts.TimeoutInspect, "Timeout for inspect requests. Example: hlgraphql --sm-deadline-inspect-state 30s")
+	cmd.Flags().DurationVar(&opts.TimeoutWorker, "timeout-worker", opts.TimeoutWorker, "Timeout for workers. Example: cartesi-rollups-graphql --timeout-worker 30s")
+	cmd.Flags().DurationVar(&opts.TimeoutInspect, "sm-deadline-inspect-state", opts.TimeoutInspect, "Timeout for inspect requests. Example: cartesi-rollups-graphql --sm-deadline-inspect-state 30s")
 
 	// disable-*
 
 	// http-*
 	cmd.Flags().StringVar(&opts.HttpAddress, "http-address", opts.HttpAddress,
-		"HTTP address used by hlgraphql to serve its APIs")
+		"HTTP address used by cartesi-rollups-graphql to serve its APIs")
 	cmd.Flags().IntVar(&opts.HttpPort, "http-port", opts.HttpPort,
-		"HTTP port used by hlgraphql to serve its external APIs")
+		"HTTP port used by cartesi-rollups-graphql to serve its external APIs")
 	cmd.Flags().IntVar(&opts.HttpRollupsPort, "http-rollups-port", opts.HttpRollupsPort,
-		"HTTP port used by hlgraphql to serve its internal APIs")
+		"HTTP port used by cartesi-rollups-graphql to serve its internal APIs")
 
 	// rpc-url
 	cmd.Flags().StringVar(&opts.RpcUrl, "rpc-url", opts.RpcUrl,
-		"If set, hlgraphql connects to this url instead of setting up Anvil")
+		"If set, cartesi-rollups-graphql connects to this url instead of setting up Anvil")
 
 	// database file
 	cmd.Flags().StringVar(&opts.SqliteFile, "sqlite-file", opts.SqliteFile,
@@ -238,7 +238,7 @@ func run(cmd *cobra.Command, args []string) {
 
 	var inspectMessage string
 
-	// start hlgraphql
+	// start cartesi-rollups-graphql
 	ready := make(chan struct{}, 1)
 	go func() {
 		select {
@@ -256,7 +256,7 @@ func run(cmd *cobra.Command, args []string) {
 				"ROLLUPS_PORT",
 				fmt.Sprint(opts.HttpRollupsPort), -1)
 			fmt.Println(msg)
-			slog.Info("hlgraphql: ready", "after", time.Since(startTime))
+			slog.Info("cartesi-rollups-graphql: ready", "after", time.Since(startTime))
 		case <-ctx.Done():
 		}
 	}()


### PR DESCRIPTION
Update all references from hlgraphql to rlgraphql in configuration files and documentation to ensure consistency.