### PR TITLE
Remove foundry on CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,11 +23,6 @@ jobs:
         with:
           go-version: "1.21"
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: ${{ env.ANVIL_TAG }}
-
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ EXPOSE 8080
 HEALTHCHECK CMD curl --fail http://localhost:8080/health || exit 1
 
 # Comando para rodar a aplicação
-CMD ["./cartesi-rollups-graphql", "--http-address=0.0.0.0", "--enable-debug", "--node-version", "v2", "--db-implementation", "postgres", "--rpc-url", "0.0.0.0" ]
+CMD ["./cartesi-rollups-graphql", "--http-address=0.0.0.0", "--enable-debug", "--node-version", "v2", "--db-implementation", "postgres", "--graphile-url", "http://postgraphile:5001/graphql", "--anvil-address", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ EXPOSE 8080
 HEALTHCHECK CMD curl --fail http://localhost:8080/health || exit 1
 
 # Comando para rodar a aplicação
-CMD ["./cartesi-rollups-graphql", "--http-address=0.0.0.0", "--enable-debug", "--node-version", "v2", "--db-implementation", "postgres", "--graphile-url", "http://postgraphile:5001/graphql", "--anvil-address", "0.0.0.0" ]
+CMD ["./cartesi-rollups-graphql", "--http-address=0.0.0.0", "--enable-debug", "--node-version", "v2", "--db-implementation", "postgres", "http://postgraphile:5001/graphql", "--rpc-url", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ EXPOSE 8080
 HEALTHCHECK CMD curl --fail http://localhost:8080/health || exit 1
 
 # Comando para rodar a aplicação
-CMD ["./cartesi-rollups-graphql", "--http-address=0.0.0.0", "--enable-debug", "--node-version", "v2", "--db-implementation", "postgres", "http://postgraphile:5001/graphql", "--rpc-url", "0.0.0.0" ]
+CMD ["./cartesi-rollups-graphql", "--http-address=0.0.0.0", "--enable-debug", "--node-version", "v2", "--db-implementation", "postgres", "--rpc-url", "0.0.0.0" ]

--- a/main.go
+++ b/main.go
@@ -142,8 +142,6 @@ func init() {
 	cmd.Flags().BoolVar(&opts.GraphileDisableSync, "graphile-disable-sync", opts.GraphileDisableSync,
 		"If set, disable graphile synchronization")
 
-	cmd.Flags().StringVar(&opts.GraphileUrl, "graphile-url", opts.GraphileUrl, "URL used to connect to Graphile")
-
 	cmd.Flags().StringVar(&opts.DbRawUrl, "db-raw-url", opts.DbRawUrl, "The raw database url")
 	cmd.Flags().BoolVar(&opts.RawEnabled, "raw-enabled", opts.RawEnabled, "If set, enables raw database")
 
@@ -219,9 +217,9 @@ func run(cmd *cobra.Command, args []string) {
 	// check args
 	checkEthAddress(cmd, "address-input-box")
 	checkEthAddress(cmd, "address-application")
-	if !cmd.Flags().Changed("sequencer") && cmd.Flags().Changed("rpc-url") && !cmd.Flags().Changed("contracts-input-box-block") {
-		exitf("must set --contracts-input-box-block when setting --rpc-url")
-	}
+	// if !cmd.Flags().Changed("sequencer") && cmd.Flags().Changed("rpc-url") && !cmd.Flags().Changed("contracts-input-box-block") {
+	// 	exitf("must set --contracts-input-box-block when setting --rpc-url")
+	// }
 	if opts.EnableEcho && len(args) > 0 {
 		exitf("can't use built-in echo with custom application")
 	}


### PR DESCRIPTION
Remove the Foundry installation step from the CI workflow and eliminate the Graphile URL flag from the Docker CMD configuration. This streamlines the setup process and updates the command to improve functionality.