### PR TITLE
Refactor load test workflow to use setup action for k6

### DIFF
--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install k6
+        uses: grafana/setup-k6-action@v1
+
       - name: up db
         run: make up-db-raw
 
@@ -45,17 +48,10 @@ jobs:
           export POSTGRES_NODE_DB_URL="postgres://postgres:password@localhost:5432/rollupsdb?sslmode=disable"
           nohup ./cartesi-rollups-graphql -d --raw-enabled --db-implementation=postgres &
 
-      - name: Install k6
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gnupg software-properties-common
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/k6-archive-keyring.gpg
-          echo "deb [signed-by=/etc/apt/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-          sudo apt-get update
-          sudo apt-get install -y k6
-
       - name: Run k6 tests
         id: k6
-        run: |
-          k6 run loadtesting/test.js
+        uses: grafana/run-k6-action@v1
+        with:
+          debug: true
+          path: |
+            ./loadtesting/test.js


### PR DESCRIPTION
Replace manual installation of k6 with a setup action in the load test workflow for improved efficiency and simplicity.